### PR TITLE
Remove projectile travel and explosion delay from DPS

### DIFF
--- a/Mehni's Misc Modifications/StatWorkers/RangedWeaponDPSUtility.cs
+++ b/Mehni's Misc Modifications/StatWorkers/RangedWeaponDPSUtility.cs
@@ -21,14 +21,13 @@ namespace Mehni.Misc.Modifications
             float accuracy = GetAccuracy(weapon, verb, projectile, dist, pawn);
             int burstCount = GetBurstCount(verb);
             float burstShotDelay = GetBurstShotDelay(verb);
-            float projectileTravelTime = GetProjectileTravelTime(projectile, dist);
-            float explosionDelay = GetExplosionDelay(projectile);
 
-            return GetDPS(damage, cooldown, warmup, accuracy, burstCount, burstShotDelay, projectileTravelTime, explosionDelay);
+            return GetDPS(damage, cooldown, warmup, accuracy, burstCount, burstShotDelay, 0, 0);
         }
 
+        // Signature retains reference to projectile travel and explosion delay for backwards compatibility.
         public static float GetDPS(float damage, float cooldown, float warmup, float accuracy, int burstCount, float burstShotDelay, float projectileTravelTime, float explosionDelay) =>
-            (damage * burstCount * accuracy) / (cooldown + warmup + ((burstCount - 1) * burstShotDelay) + projectileTravelTime + explosionDelay);
+            (damage * burstCount * accuracy) / (cooldown + warmup + ((burstCount - 1) * burstShotDelay));
 
         public static string GetExplanation(Thing weapon, float dist, Pawn pawn = null)
         {
@@ -68,14 +67,15 @@ namespace Mehni.Misc.Modifications
             if (bCMinOne > 0)
                 expBuilder.AppendLine($"{"M4_BurstShotDelay".Translate()}: {bCMinOne * burstShotDelay:F2} s ({bCMinOne} x {burstShotDelay:F2})");
 
+            expBuilder.AppendLine();
+            expBuilder.AppendLine($"DPS = ({burstCount * damage} x {accuracy.ToStringPercent()}) /" +
+                $" {cooldown + warmup + (bCMinOne * burstShotDelay):F2}");
+
             // Projectile 
+            expBuilder.AppendLine();
             _ = expBuilder.AppendLine($"{"M4_ProjectileTravelTime".Translate()}: {projectileTravelTime:F2} s");
             if (explosionDelay > 0f)
                 _ = expBuilder.AppendLine($"{"M4_ProjectileExplosionDelay".Translate()}: {explosionDelay:F2} s");
-
-            expBuilder.AppendLine();
-            expBuilder.AppendLine($"DPS = ({burstCount * damage} x {accuracy.ToStringPercent()}) /" +
-                $" {cooldown + warmup + (bCMinOne * burstShotDelay) + projectileTravelTime + explosionDelay:F2}");
 
             return expBuilder.ToString();
         }


### PR DESCRIPTION
- Updated DPS equations to no longer include projectile travel time and explosion delay, since those overlap with the cooldown (and possibly following warmup).
- Removed the projectile travel time and explosion delay elements from the DPS explanation math, and moved the lines for those elements below the DPS calculations.
- The expression version of GetDPS() still accepts the projectileTravelTime and explosionDelay parameters, just in case anyone else out there is using that function for something.  It just doesn't use them anymore.

Per our conversion on Discord.  Also, I left the travel time lines inside the DPS explanation (but moved them around a bit, to try to reduce the implication that they affect DPS), but it could probably work simply as an independent stat def instead, as it's not used by those DPS calculations at all anymore.  If done that way, it should probably just be the raw projectile speed, rather than calculated as time-to-hit at a various ranges.

For the sake of others (and/or us later) reading this PR:

Travel time doesn't impact DPS because it strictly overlaps with the cooldown of the weapon, in that the weapon doesn't have to wait for the projectile to hit before it can start cooling down (or in fact, before it can fire again.  Tested with a weapon PATCHed to projectile speed 1, pawn had 4 volleys in the air before the first had traveled 10 cells).  Travel time only impacts time-until-DPS-starts.  If a pawn is continuously firing a weapon at a stationary target, once the first round reaches the target, the actual applied DPS (averaged based on accuracy) will not be based on the travel time at all, strictly the base burst damage, accuracy, warmup time, cooldown time, and burst delay (if applicable).

Against a moving target, travel time slightly matters, though pawns typically have a fraction of the move speed of projectiles.  In addition, the _effect_ of travel time on DPS depends _very_ heavily on both the speed and _direction_ of the target, due to the bullet equivalent of the Doppler Effect (ie. a target moving towards the shooter receives more DPS and a target moving away less, proportional to their radial velocity relative to the shooter's position, with projectile speed acting to proportionately reduce but never really eliminate that effect).  Since this is extremely situation-dependent (somewhat like the effects of armor and armor penetration), it should not be included in the calculations.  In practice, projectile speed typically impacts DPS _far_ less than armor penetration, which is already excluded due to the situational effect it has (ranging from zilch on a zero-armor target to infinite on an otherwise-undamageable target that armor penetration then permits to be damaged).